### PR TITLE
updating mosek use to be functional

### DIFF
--- a/src/CVChannel.jl
+++ b/src/CVChannel.jl
@@ -38,7 +38,7 @@ include("states.jl")
 export choi, depolarizingChannel, dephrasureChannel, wernerHolevoChannel
 include("channels.jl")
 
-export qsolve!, useMOSEK, useSCS, hasMOSEKLicense
+export qsolve!, hasMOSEKLicense
 include("optimizer_interface.jl")
 
 export eaCVPrimal, eaCVDual, pptCVPrimal, pptCVDual

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,6 @@ println("running ./test/CVChannel.jl")
 
     println("testing ./src/optimizer_interface.jl")
     @time @safetestset "./test/optimizer_interface.jl" begin include("optimizer_interface.jl") end
-
 end
 
 println("\ntotal elapsed time :")


### PR DESCRIPTION
@igeorge3 I made some changes to the mosek interface. I removed the object-oriented `_USE_MOSEK` flag in favor of a more functional approach,  e.g. `qsolve!(problem, use_mosek = true)`. This makes it easier to test, and allows us to remove some extraneous code. Also in regards to testing MOSEK, I've set it up so that if a license is found locally, Mosek will be tested. Otherwise, the test will be skipped and a Warning will be thrown to indicate that a test was skipped. If you check the automated tests, you'll see the `Warning`. This is intended behavior because we can't guarantee a working mosek license in the test environment indefinitely.

Let me know if you have any questions or concerns.